### PR TITLE
Export fix and save on export

### DIFF
--- a/TexturePackTool/MainWindow.xaml.cs
+++ b/TexturePackTool/MainWindow.xaml.cs
@@ -606,6 +606,9 @@ namespace TexturePackTool
             {
                 DrawSpriteSheet(sheet);
             }
+
+            // Saves exported image dimensions.
+            SaveProject();
         }
         #endregion
         #endregion

--- a/TexturePackTool/Model/Frame.cs
+++ b/TexturePackTool/Model/Frame.cs
@@ -158,7 +158,7 @@ namespace TexturePackTool.Model
         /// </param>
         public void SetRelativePath(Uri absPath, Uri root)
         {
-            RelativePath = root.MakeRelativeUri(absPath).ToString();
+            RelativePath = Uri.UnescapeDataString(root.MakeRelativeUri(absPath).ToString());
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs("RelativePath"));
             RelativePathChanged?.Invoke();
         }


### PR DESCRIPTION
Escapes the url encoded as a side-effect by MakeRelativeUri.
Saves the project after exporting so x, y, width, height is updated in the json file.